### PR TITLE
NondyadicFilters

### DIFF
--- a/src/transforms_filter.jl
+++ b/src/transforms_filter.jl
@@ -7,13 +7,13 @@
 ##################################################################################
 
 function makeqmf(h::AbstractVector, fw::Bool, T::Type=eltype(h))
-	scfilter, dcfilter = makereverseqmf(h, fw, T)
+    scfilter, dcfilter = makereverseqmf(h, fw, T)
     return reverse(scfilter), reverse(dcfilter)
 end
 function makereverseqmf(h::AbstractVector, fw::Bool, T::Type=eltype(h))
-	h = convert(Vector{T}, h)
+    h = convert(Vector{T}, h)
     if fw
-    	scfilter = reverse(h)
+        scfilter = reverse(h)
         dcfilter = mirror(h)
     else
         scfilter = h
@@ -47,7 +47,7 @@ end
 function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, L::Integer, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T}, snew::Vector{T} = Array(T, ifelse(L>1, length(x)>>1, 0)))
     n = length(x)
     @assert size(x) == size(y)
-	@assert sufficientpowersoftwo(y, L)
+    @assert sufficientpowersoftwo(y, L)
     @assert 0 <= L 
     is(y,x) && error("input vector is output vector")
     
@@ -57,11 +57,11 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
     filtlen = length(filter)
     
     if fw
-		lrange = 1:L
+        lrange = 1:L
     else
-		lrange = L:-1:1
+        lrange = L:-1:1
     end
-	for l in lrange
+    for l in lrange
         if fw
             # detail coefficients
             filtdown!(dcfilter, si, y, detailindex(n,l,1), detailn(n,l), s, 1,-filtlen+1, true)
@@ -82,7 +82,7 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
 end
 function unsafe_dwt1level!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T})
     n = length(x)
-	l = 1
+    l = 1
     filtlen = length(filter)
 
     if fw
@@ -115,7 +115,7 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
     n = size(x,1)
     @assert size(x) == size(y)
     @assert iscube(y)
-	@assert sufficientpowersoftwo(y, L)
+    @assert sufficientpowersoftwo(y, L)
     @assert 0 <= L 
     @assert length(tmpvec) >= n<<1
     is(y,x) && error("input matrix is output matrix")
@@ -125,22 +125,22 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
     #s = x
 
     if fw
-		lrange = 1:L
+        lrange = 1:L
         nsub = n
     else
-		lrange = L:-1:1
-		nsub = div(n,2^(L-1))
+        lrange = L:-1:1
+        nsub = div(n,2^(L-1))
         copy!(y,x)
     end
 
-	for l in lrange
+    for l in lrange
         tmpsub = unsafe_vectorslice(tmpvec, 1, nsub)
         tmpsub2 = unsafe_vectorslice(tmpvec, nsub+1, nsub)
         if fw
             # rows
             for i=1:nsub
                 xi = i
-				if l != lrange[1]
+                if l != lrange[1]
                     stridedcopy!(tmpsub, y, xi, xs, nsub)
                 else  # use x in first iteration
                     stridedcopy!(tmpsub, x, xi, xs, nsub)
@@ -160,7 +160,7 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
             for i=1:nsub
                 xi = 1+(i-1)*n
                 ya = unsafe_vectorslice(y, xi, nsub)
-				if l != lrange[1]
+                if l != lrange[1]
                     copy!(tmpsub,1,ya,1,nsub)
                     unsafe_dwt1level!(ya, tmpsub, filter, fw, dcfilter, scfilter, si)
                 else  # use x in first iteration

--- a/src/transforms_filter.jl
+++ b/src/transforms_filter.jl
@@ -82,7 +82,7 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
 end
 function unsafe_dwt1level!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T})
     n = length(x)
-	l = 1 # FIXME: Check this should be 1, not 0, or something else. 
+	l = 1
     filtlen = length(filter)
 
     if fw

--- a/src/transforms_filter.jl
+++ b/src/transforms_filter.jl
@@ -46,10 +46,11 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
 end
 function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, L::Integer, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T}, snew::Vector{T} = Array(T, ifelse(L>1, length(x)>>1, 0)))
     n = length(x)
-    J = nscales(n)
+    #J = nscales(n)
     @assert size(x) == size(y)
-    @assert isdyadic(y)
-    @assert 0 <= L <= J
+    #@assert isdyadic(y)
+	@assert sufficientpowersoftwo(y, L)
+    @assert 0 <= L # <= J # FIXME: Remove entirely??
     is(y,x) && error("input vector is output vector")
     
     L == 0 && return copy!(y,x)     # do nothing
@@ -58,44 +59,58 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
     filtlen = length(filter)
     
     if fw
-        jrange = (J-1):-1:(J-L)
+        #jrange = (J-1):-1:(J-L)
+		lrange = 1:L
     else
-        jrange = (J-L):(J-1)
+        #jrange = (J-L):(J-1)
+		lrange = L:-1:1
     end
-    for j in jrange
+    #for j in jrange
+	for l in lrange
         if fw
             # detail coefficients
-            filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), s, 1,-filtlen+1, true)
+            #filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), s, 1,-filtlen+1, true)
+            filtdown!(dcfilter, si, y, detailindex(n,l,1), detailn(n,l), s, 1,-filtlen+1, true)
             # scaling coefficients
-            filtdown!(scfilter, si, y,                1, detailn(j), s, 1, 0, false)
+            #filtdown!(scfilter, si, y,                1, detailn(j), s, 1, 0, false)
+            filtdown!(scfilter, si, y,                1, detailn(n,l), s, 1, 0, false)
         else
             # scaling coefficients
-            filtup!(false, scfilter, si, y, 1, detailn(j+1), s, 1, -filtlen+1, false)
+            #filtup!(false, scfilter, si, y, 1, detailn(j+1), s, 1, -filtlen+1, false)
+            filtup!(false, scfilter, si, y, 1, detailn(n,l-1), s, 1, -filtlen+1, false)
             # detail coefficients
-            filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
+            #filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
+            filtup!(true,  dcfilter, si, y, 1, detailn(n,l-1), x, detailindex(n,l,1), 0, true)
         end
         # if not final iteration: copy to tmp location
-        fw  && j != jrange[end] && copy!(snew,1,y,1,detailn(j))
-        !fw && j != jrange[end] && copy!(snew,1,y,1,detailn(j+1))
+        #fw  && j != jrange[end] && copy!(snew,1,y,1,detailn(j))
+        #!fw && j != jrange[end] && copy!(snew,1,y,1,detailn(j+1))
+        fw  && l != lrange[end] && copy!(snew,1,y,1,detailn(n,l))
+        !fw && l != lrange[end] && copy!(snew,1,y,1,detailn(n,l-1))
         L > 1 && (s = snew)
     end
     return y
 end
 function unsafe_dwt1level!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T})
     n = length(x)
-    j = nscales(n) - 1
+    #j = nscales(n) - 1
+	l = 1 # FIXME: Check this should be 1, not 0, or something else. 
     filtlen = length(filter)
 
     if fw
         # detail coefficients
-        filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), x, 1,-filtlen+1, true)
+        #filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), x, 1,-filtlen+1, true)
+        filtdown!(dcfilter, si, y, detailindex(n,l,1), detailn(n,l), x, 1,-filtlen+1, true)
         # scaling coefficients
-        filtdown!(scfilter, si, y,                1, detailn(j), x, 1, 0, false)
+        #filtdown!(scfilter, si, y,                1, detailn(j), x, 1, 0, false)
+        filtdown!(scfilter, si, y,                1, detailn(n,l), x, 1, 0, false)
     else
         # scaling coefficients
-        filtup!(false, scfilter, si, y, 1, detailn(j+1), x, 1, -filtlen+1, false)
+        #filtup!(false, scfilter, si, y, 1, detailn(j+1), x, 1, -filtlen+1, false)
+        filtup!(false, scfilter, si, y, 1, detailn(n,l-1), x, 1, -filtlen+1, false)
         # detail coefficients
-        filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
+        #filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
+        filtup!(true,  dcfilter, si, y, 1, detailn(n,l-1), x, detailindex(n,l,1), 0, true)
     end
     return y
 end
@@ -114,11 +129,12 @@ end
 function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::OrthoFilter, L::Integer, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T}, tmpvec::Vector{T})
 
     n = size(x,1)
-    J = nscales(n)
+    #J = nscales(n)
     @assert size(x) == size(y)
     @assert iscube(y)
-    @assert isdyadic(y)
-    @assert 0 <= L <= J
+    #@assert isdyadic(y)
+	@assert sufficientpowersoftwo(y, L)
+    @assert 0 <= L #<= J # FIXME: Remove entirely??
     @assert length(tmpvec) >= n<<1
     is(y,x) && error("input matrix is output matrix")
     
@@ -127,22 +143,27 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
     #s = x
 
     if fw
-        jrange = (J-1):-1:(J-L)
+        #jrange = (J-1):-1:(J-L)
+		lrange = 1:L
         nsub = n
     else
-        jrange = (J-L):(J-1)
-        nsub = int(2^(J-L+1))
+        #jrange = (J-L):(J-1)
+		lrange = L:-1:1
+        #nsub = int(2^(J-L+1))
+		nsub = div(n,2^(L-1))
         copy!(y,x)
     end
 
-    for j in jrange
+    #for j in jrange
+	for l in lrange
         tmpsub = unsafe_vectorslice(tmpvec, 1, nsub)
         tmpsub2 = unsafe_vectorslice(tmpvec, nsub+1, nsub)
         if fw
             # rows
             for i=1:nsub
                 xi = i
-                if j != jrange[1]
+                #if j != jrange[1]
+				if l != lrange[1]
                     stridedcopy!(tmpsub, y, xi, xs, nsub)
                 else  # use x in first iteration
                     stridedcopy!(tmpsub, x, xi, xs, nsub)
@@ -162,7 +183,8 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
             for i=1:nsub
                 xi = 1+(i-1)*n
                 ya = unsafe_vectorslice(y, xi, nsub)
-                if j != jrange[1]
+                #if j != jrange[1]
+				if l != lrange[1]
                     copy!(tmpsub,1,ya,1,nsub)
                     unsafe_dwt1level!(ya, tmpsub, filter, fw, dcfilter, scfilter, si)
                 else  # use x in first iteration

--- a/src/transforms_filter.jl
+++ b/src/transforms_filter.jl
@@ -46,11 +46,9 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
 end
 function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, L::Integer, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T}, snew::Vector{T} = Array(T, ifelse(L>1, length(x)>>1, 0)))
     n = length(x)
-    #J = nscales(n)
     @assert size(x) == size(y)
-    #@assert isdyadic(y)
 	@assert sufficientpowersoftwo(y, L)
-    @assert 0 <= L # <= J # FIXME: Remove entirely??
+    @assert 0 <= L 
     is(y,x) && error("input vector is output vector")
     
     L == 0 && return copy!(y,x)     # do nothing
@@ -59,32 +57,23 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
     filtlen = length(filter)
     
     if fw
-        #jrange = (J-1):-1:(J-L)
 		lrange = 1:L
     else
-        #jrange = (J-L):(J-1)
 		lrange = L:-1:1
     end
-    #for j in jrange
 	for l in lrange
         if fw
             # detail coefficients
-            #filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), s, 1,-filtlen+1, true)
             filtdown!(dcfilter, si, y, detailindex(n,l,1), detailn(n,l), s, 1,-filtlen+1, true)
             # scaling coefficients
-            #filtdown!(scfilter, si, y,                1, detailn(j), s, 1, 0, false)
             filtdown!(scfilter, si, y,                1, detailn(n,l), s, 1, 0, false)
         else
             # scaling coefficients
-            #filtup!(false, scfilter, si, y, 1, detailn(j+1), s, 1, -filtlen+1, false)
             filtup!(false, scfilter, si, y, 1, detailn(n,l-1), s, 1, -filtlen+1, false)
             # detail coefficients
-            #filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
             filtup!(true,  dcfilter, si, y, 1, detailn(n,l-1), x, detailindex(n,l,1), 0, true)
         end
         # if not final iteration: copy to tmp location
-        #fw  && j != jrange[end] && copy!(snew,1,y,1,detailn(j))
-        #!fw && j != jrange[end] && copy!(snew,1,y,1,detailn(j+1))
         fw  && l != lrange[end] && copy!(snew,1,y,1,detailn(n,l))
         !fw && l != lrange[end] && copy!(snew,1,y,1,detailn(n,l-1))
         L > 1 && (s = snew)
@@ -93,23 +82,18 @@ function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filt
 end
 function unsafe_dwt1level!{T<:FloatingPoint}(y::AbstractVector{T}, x::AbstractVector{T}, filter::OrthoFilter, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T})
     n = length(x)
-    #j = nscales(n) - 1
 	l = 1 # FIXME: Check this should be 1, not 0, or something else. 
     filtlen = length(filter)
 
     if fw
         # detail coefficients
-        #filtdown!(dcfilter, si, y, detailindex(j,1), detailn(j), x, 1,-filtlen+1, true)
         filtdown!(dcfilter, si, y, detailindex(n,l,1), detailn(n,l), x, 1,-filtlen+1, true)
         # scaling coefficients
-        #filtdown!(scfilter, si, y,                1, detailn(j), x, 1, 0, false)
         filtdown!(scfilter, si, y,                1, detailn(n,l), x, 1, 0, false)
     else
         # scaling coefficients
-        #filtup!(false, scfilter, si, y, 1, detailn(j+1), x, 1, -filtlen+1, false)
         filtup!(false, scfilter, si, y, 1, detailn(n,l-1), x, 1, -filtlen+1, false)
         # detail coefficients
-        #filtup!(true,  dcfilter, si, y, 1, detailn(j+1), x, detailindex(j,1), 0, true)
         filtup!(true,  dcfilter, si, y, 1, detailn(n,l-1), x, detailindex(n,l,1), 0, true)
     end
     return y
@@ -129,12 +113,10 @@ end
 function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::OrthoFilter, L::Integer, fw::Bool, dcfilter::Vector{T}, scfilter::Vector{T}, si::Vector{T}, tmpvec::Vector{T})
 
     n = size(x,1)
-    #J = nscales(n)
     @assert size(x) == size(y)
     @assert iscube(y)
-    #@assert isdyadic(y)
 	@assert sufficientpowersoftwo(y, L)
-    @assert 0 <= L #<= J # FIXME: Remove entirely??
+    @assert 0 <= L 
     @assert length(tmpvec) >= n<<1
     is(y,x) && error("input matrix is output matrix")
     
@@ -143,18 +125,14 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
     #s = x
 
     if fw
-        #jrange = (J-1):-1:(J-L)
 		lrange = 1:L
         nsub = n
     else
-        #jrange = (J-L):(J-1)
 		lrange = L:-1:1
-        #nsub = int(2^(J-L+1))
 		nsub = div(n,2^(L-1))
         copy!(y,x)
     end
 
-    #for j in jrange
 	for l in lrange
         tmpsub = unsafe_vectorslice(tmpvec, 1, nsub)
         tmpsub2 = unsafe_vectorslice(tmpvec, nsub+1, nsub)
@@ -162,7 +140,6 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
             # rows
             for i=1:nsub
                 xi = i
-                #if j != jrange[1]
 				if l != lrange[1]
                     stridedcopy!(tmpsub, y, xi, xs, nsub)
                 else  # use x in first iteration
@@ -183,7 +160,6 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, x::AbstractMatrix{T}, filter::Orth
             for i=1:nsub
                 xi = 1+(i-1)*n
                 ya = unsafe_vectorslice(y, xi, nsub)
-                #if j != jrange[1]
 				if l != lrange[1]
                     copy!(tmpsub,1,ya,1,nsub)
                     unsafe_dwt1level!(ya, tmpsub, filter, fw, dcfilter, scfilter, si)

--- a/src/transforms_lifting.jl
+++ b/src/transforms_lifting.jl
@@ -32,25 +32,30 @@ end
 function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, scheme::GLS, L::Integer, fw::Bool, tmp::Vector{T}=Array(T,length(y)>>2))
 
     n = length(y)
-    J = nscales(n)
-    @assert isdyadic(y)
-    @assert 0 <= L <= J
+    #J = nscales(n)
+    #@assert isdyadic(y)
+    @assert sufficientpowersoftwo(y,L)
+    @assert 0 <= L #<= J
     @assert length(tmp) >= n>>2
     L == 0 && return y          # do nothing
     
     if fw
-        jrange = (J-1):-1:(J-L)
+        #jrange = (J-1):-1:(J-L)
+        lrange = 1:L
         ns = n
         half = ns>>1
     else
-        jrange = (J-L):(J-1)
-        ns = 2^(jrange[1]+1)
+        #jrange = (J-L):(J-1)
+        lrange = L:-1:1
+        #ns = 2^(jrange[1]+1)
+        ns = div(n,(2^(lrange[1]-1)))
         half = ns>>1
     end
     s = y
     stepseq, norm1, norm2 = makescheme(T, scheme, fw)
 
-    for j in jrange
+    #for j in jrange
+    for l in lrange
         if fw
             split!(s, ns, tmp)
             for step in stepseq
@@ -143,26 +148,31 @@ end
 function dwt!{T<:FloatingPoint}(y::Matrix{T}, scheme::GLS, L::Integer, fw::Bool, tmp::Vector{T}=Array(T,size(y,1)>>2), tmpvec::Vector{T}=Array(T,size(y,1)))
 
     n = size(y,1)
-    J = nscales(n)
+    #J = nscales(n)
     @assert iscube(y)
-    @assert isdyadic(y)
-    @assert 0 <= L <= J
+    #@assert isdyadic(y)
+    @assert sufficientpowersoftwo(y,L)
+    @assert 0 <= L #<= J
     @assert length(tmp) >= n>>2
     @assert length(tmpvec) >= n
     L == 0 && return y          # do nothing
     
     if fw
-        jrange = (J-1):-1:(J-L)
+        #jrange = (J-1):-1:(J-L)
+        lrange = 1:L
         nsub = n
     else
-        jrange = (J-L):(J-1)
-        nsub = int(2^(J-L+1))
+        #jrange = (J-L):(J-1)
+        lrange = L:-1:1
+        #nsub = int(2^(J-L+1))
+        nsub = div(n,2^(L-1))
     end
     stepseq, norm1, norm2 = makescheme(T, scheme, fw)
     
     xm = 0
     xs = n
-    for j in jrange
+    #for j in jrange
+    for l in lrange
         tmpsub = unsafe_vectorslice(tmpvec, 1, nsub)
         if fw
             # rows
@@ -312,7 +322,7 @@ end # for
 function getliftranges(half::Int, nc::Int, shift::Int, pred::Bool)
     # define index shift rhsis
     if pred
-    	rhsis = -shift+half
+        rhsis = -shift+half
     else
         rhsis = -shift-half
     end
@@ -338,9 +348,9 @@ function getliftranges(half::Int, nc::Int, shift::Int, pred::Bool)
         rhsr = irmax+1:half
     end
     if !(pred)  # shift ranges for update
-    	irange += half
-    	lhsr += half
-    	rhsr += half
+        irange += half
+        lhsr += half
+        rhsr += half
     end
     return (lhsr, irange, rhsr, rhsis)
 end

--- a/src/transforms_lifting.jl
+++ b/src/transforms_lifting.jl
@@ -32,29 +32,23 @@ end
 function dwt!{T<:FloatingPoint}(y::AbstractVector{T}, scheme::GLS, L::Integer, fw::Bool, tmp::Vector{T}=Array(T,length(y)>>2))
 
     n = length(y)
-    #J = nscales(n)
-    #@assert isdyadic(y)
     @assert sufficientpowersoftwo(y,L)
     @assert 0 <= L #<= J
     @assert length(tmp) >= n>>2
     L == 0 && return y          # do nothing
     
     if fw
-        #jrange = (J-1):-1:(J-L)
         lrange = 1:L
         ns = n
         half = ns>>1
     else
-        #jrange = (J-L):(J-1)
         lrange = L:-1:1
-        #ns = 2^(jrange[1]+1)
         ns = div(n,(2^(lrange[1]-1)))
         half = ns>>1
     end
     s = y
     stepseq, norm1, norm2 = makescheme(T, scheme, fw)
 
-    #for j in jrange
     for l in lrange
         if fw
             split!(s, ns, tmp)
@@ -148,9 +142,7 @@ end
 function dwt!{T<:FloatingPoint}(y::Matrix{T}, scheme::GLS, L::Integer, fw::Bool, tmp::Vector{T}=Array(T,size(y,1)>>2), tmpvec::Vector{T}=Array(T,size(y,1)))
 
     n = size(y,1)
-    #J = nscales(n)
     @assert iscube(y)
-    #@assert isdyadic(y)
     @assert sufficientpowersoftwo(y,L)
     @assert 0 <= L #<= J
     @assert length(tmp) >= n>>2
@@ -158,20 +150,16 @@ function dwt!{T<:FloatingPoint}(y::Matrix{T}, scheme::GLS, L::Integer, fw::Bool,
     L == 0 && return y          # do nothing
     
     if fw
-        #jrange = (J-1):-1:(J-L)
         lrange = 1:L
         nsub = n
     else
-        #jrange = (J-L):(J-1)
         lrange = L:-1:1
-        #nsub = int(2^(J-L+1))
         nsub = div(n,2^(L-1))
     end
     stepseq, norm1, norm2 = makescheme(T, scheme, fw)
     
     xm = 0
     xs = n
-    #for j in jrange
     for l in lrange
         tmpsub = unsafe_vectorslice(tmpvec, 1, nsub)
         if fw

--- a/src/util.jl
+++ b/src/util.jl
@@ -28,6 +28,14 @@ tl2level(x::Vector, L::Integer) = tl2level(length(x), L)
 # convert maximum level j to number of transformed levels L
 level2tl(arg...) = tl2level(arg...)
 
+# Non-dyadic Wavelet Indexing and sizes
+# detail coef at level l location i (i starting at 1) -> vector index
+detailindex(arraysize::Integer, l::Integer, i::Integer) = int(arraysize/2^l+i)
+# the range of detail coefs at level l
+detailrange(arraysize::Integer, l::Integer) = int((arraysize/2^l+1)):(int(arraysize/2^(l-1)))
+# number of detail coefs at level l
+detailn(arraysize::Integer, l::Integer) = int(arraysize/2^l)
+
 
 # UTILITY FUNCTIONS
 
@@ -74,6 +82,17 @@ function isdyadic(x::AbstractArray)
         n != 2^J && return false
     end
     return true
+end
+
+# To perform a level L transform, the suport of the signal in each dimension must have 
+# 2^L as a factor. Check this:
+function sufficientpowersoftwo(x::AbstractArray, L::Integer)
+	for i = 1:ndims(x)
+		n = size(x,i)
+		fact = 2^L
+		n%fact != 0 && return false
+	end
+	return true
 end
 
 # count coefficients above threshold t (>=), excluding coefficients in levels < level

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,6 +1,6 @@
 module Util
 export detailindex, detailrange, scalingrange, detailn, nscales, maxlevel, tl2level, level2tl, 
-    mirror, upsample, downsample, iscube, isdyadic, wcount, circshift!,
+    mirror, upsample, downsample, iscube, isdyadic, sufficientpowersoftwo, wcount, circshift!,
     split!, merge!, stridedcopy!,
     isvalidtree, maketree,
     makewavelet, testfunction

--- a/src/util.jl
+++ b/src/util.jl
@@ -87,12 +87,12 @@ end
 # To perform a level L transform, the suport of the signal in each dimension must have 
 # 2^L as a factor. Check this:
 function sufficientpowersoftwo(x::AbstractArray, L::Integer)
-	for i = 1:ndims(x)
-		n = size(x,i)
-		fact = 2^L
-		n%fact != 0 && return false
-	end
-	return true
+    for i = 1:ndims(x)
+        n = size(x,i)
+        fact = 2^L
+        n%fact != 0 && return false
+    end
+    return true
 end
 
 # count coefficients above threshold t (>=), excluding coefficients in levels < level
@@ -381,19 +381,19 @@ end
 # iterated with a cascade algorithm with N steps
 makewavelet(h, arg...) = makewavelet(h.qmf, arg...)
 function makewavelet(h::AbstractVector, N::Integer=8)
-	@assert N>=0
-	sc = norm(h)
-	h = h*sqrt(2)/sc
-	phi = copy(h)
-	psi = mirror(reverse(h))
+    @assert N>=0
+    sc = norm(h)
+    h = h*sqrt(2)/sc
+    phi = copy(h)
+    psi = mirror(reverse(h))
 
-	for i=1:N
-		phi = conv(upsample(phi), h)
-		psi = conv(upsample(psi), h)
-	end
-	phi = phi[1:end-2^(N)+1]
-	psi = psi[1:end-2^(N)+1]
-	return scale!(phi,sc/sqrt(2)), scale!(psi,sc/sqrt(2)), linspace(0,length(h)-1,length(psi))
+    for i=1:N
+        phi = conv(upsample(phi), h)
+        psi = conv(upsample(psi), h)
+    end
+    phi = phi[1:end-2^(N)+1]
+    psi = psi[1:end-2^(N)+1]
+    return scale!(phi,sc/sqrt(2)), scale!(psi,sc/sqrt(2)), linspace(0,length(h)-1,length(psi))
 end
 
 # return a vector of test function values on [0,1), see


### PR DESCRIPTION
Some utility functions and modifications to transforms_filter.jl to support non-dyadic length signals in 1 and 2 dimensions when using filter-based transforms. For a transform by L levels, the length of the signal must be divisible by 2^L. For 2 dimensions, the requirement that the length of the signal be the same in both dimensions remains unchanged. 

This PR changes a fundamental assumption underlying the inner loops. Previously, all input and output signals from filtdown and filtup were defined to be even in length (I think). Now, the output of filtdown and the input of filtup can be odd in length. As far as I can tell, this doesn't break anything. But its possible that some corner cases may cause something odd to happen. The only test I've tried (other than the test suite) is to transform signals whose length is divisible by 2^L, but not by 2^(L+1), thereby ensuring the final filtdown output has odd length, and the first filtup input has even length. 

I've only changed transforms_filter because I don't understand lifting yet. I'm going to look at that next. If you want to delay incorporating the PR until non-dyadic lifting is added, that's fine. I thought you might want to see the direction this work is going in. I'd like to know if I've accidentally broken something too :)