### PR TITLE
max transform -> minimum possible of an array

### DIFF
--- a/src/mod/Util.jl
+++ b/src/mod/Util.jl
@@ -47,7 +47,7 @@ detailrange(x::AbstractArray, l::Integer) = detailrange(size(x,1), l)
 detailn(arraysize::Integer, l::Integer) = round(Int, arraysize/2^l)
 detailn(x::AbstractArray, l::Integer) = detailn(size(x,1), l)
 # max levels to transform
-maxtransformlevels(x::AbstractArray) = maxtransformlevels(minimum(size(x)))
+maxtransformlevels(x::AbstractArray) = minimum(maxtransformlevels.(size(x)))
 function maxtransformlevels(arraysize::Integer)
     arraysize > 1 || return 0
     tl = 0

--- a/test/util.jl
+++ b/test/util.jl
@@ -22,6 +22,7 @@
     L = 2
     @test maxtransformlevels(n) == ndyadicscales(n)
     @test maxtransformlevels(n) == maxmodwttransformlevels(n)
+    @test maxtransformlevels(zeros(Int,24,12)) == 2
     @test detailindex(n, L, 3) == dyadicdetailindex(tl2dyadiclevel(n,L), 3)
     @test detailrange(n, L) == dyadicdetailrange(tl2dyadiclevel(n,L))
     @test detailn(n, L) == dyadicdetailn(tl2dyadiclevel(n,L))


### PR DESCRIPTION
Hi,
Just a little PR :
Wavelets transform level should take the minimum value of L rather than the maximum.

I also add a test for that purpose
---
Related to this issue : https://github.com/MagneticResonanceImaging/MRIReco.jl/issues/78