### PR TITLE
Remove unused type parameter

### DIFF
--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -214,7 +214,7 @@ end
 
 
 function cwt(Y::AbstractArray{T,N}, c::CFW{W, S, WaTy}, daughters, rfftPlan =
-             plan_rfft([1])) where {N, T<:Real, S<:Real, U<:Number,
+             plan_rfft([1])) where {N, T<:Real, S<:Real,
                                     W<:WT.WaveletBoundary, WaTy<:WT.Dog}
     # Dog doesn't need a fft because it is strictly real
     # TODO: complex input version of this

--- a/src/mod/WT.jl
+++ b/src/mod/WT.jl
@@ -657,18 +657,15 @@ end
 
 # it's ok to just hand the total size, even if we're not transforming across
 # all dimensions
-function computeWavelets(Y::Tuple, c::CFW{W}; T=Float64) where {S<:Real,
-                                                     W<:WT.WaveletBoundary}
+function computeWavelets(Y::Tuple, c::CFW{W}; T=Float64) where {W<:WT.WaveletBoundary}
     return computeWavelets(Y[1], c; T=T)
 end
-function computeWavelets(Y::AbstractArray{<:Integer}, c::CFW{W}; T=Float64) where {S<:Real,
-                                                     W<:WT.WaveletBoundary}
+function computeWavelets(Y::AbstractArray{<:Integer}, c::CFW{W}; T=Float64) where {W<:WT.WaveletBoundary}
     return computeWavelets(Y[1], c, T=T)
 end
 
 # also ok to just hand the whole thing being transformed
-function computeWavelets(Y::AbstractArray{<:Number}, c::CFW{W}; T=Float64) where {S<:Real,
-                                                     W<:WT.WaveletBoundary}
+function computeWavelets(Y::AbstractArray{<:Number}, c::CFW{W}; T=Float64) where {W<:WT.WaveletBoundary}
     return computeWavelets(size(Y)[1], c, T=T)
 end
 


### PR DESCRIPTION
As the title says, there are some type parameters that are not in use. This gives a warning during pre-compilation.