### PR TITLE
removing CWT: Wavelets.jl needs a version bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Wavelets"
 uuid = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 author = ["Gudmundur Adalsteinsson"]
-version = "0.9.5"
+version = "0.10.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"


### PR DESCRIPTION
The version in the repository still has all of the CWT methods, so the package version needs a bump; incrementing the minor version seemed appropriate.