### PR TITLE
Drop FFTW as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "Wavelets"
 uuid = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
-author = ["Gudmundur Adalsteinsson"]
 version = "0.10.1"
+author = ["Gudmundur Adalsteinsson"]
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -13,7 +12,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DSP = "0.5.1, 0.6, 0.7, 0.8"
-FFTW = "0.3, 1"
 LinearAlgebra = "1"
 Reexport = "0.2, 1.0"
 SpecialFunctions = "0.7.1, 0.8, 0.9, 0.10, 1, 2"

--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -3,7 +3,6 @@ export  dwt, idwt, dwt!, idwt!,
         wpt, iwpt, wpt!, iwpt!,
         modwt, imodwt
 using ..Util, ..WT
-using FFTW
 
 # TODO Use StridedArray instead of AbstractArray where writing to array.
 # TODO change integer dependent wavelets to parametric types (see "Value types", https://docs.julialang.org/en/v1/manual/types/index.html#%22Value-types%22-1)


### PR DESCRIPTION
It is not used. FFTW is available under GPL, so the removal would make it easier to use this package in some projects.