### PR TITLE
run CI on any PR

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,12 +1,18 @@
 name: CI
+
 on:
   pull_request:
-    branches:
-      - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
     tags: '*'
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -28,7 +34,7 @@ jobs:
             version: '1'
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -42,8 +48,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:


### PR DESCRIPTION
The existing CI workflow seems to have been set up in a way that PRs like #110 did not run the CI.
This change hopefully should ensure that CI is run for any PR (including this one!).