### PR TITLE
Add compat entries for the extensions, Julia v1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1'
+        version: ['1.10', '1']
         os:
           - windows-latest
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,11 +24,11 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
-          - macos-26-intel
+          - macos-latest
         arch:
-          - x64
+          - default
         include:
-          - os: macOS-latest
+          - os: macos-26-intel
             arch: default
             version: '1'
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,8 @@ WaveletsGPUExt = ["GPUArrays", "KernelAbstractions"]
 
 [compat]
 DSP = "0.5.1, 0.6, 0.7, 0.8"
+GPUArrays = "11"
+KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 Reexport = "0.2, 1.0"
 SpecialFunctions = "0.7.1, 0.8, 0.9, 0.10, 1, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ WaveletsGPUExt = ["GPUArrays", "KernelAbstractions"]
 
 [compat]
 DSP = "0.5.1, 0.6, 0.7, 0.8"
-GPUArrays = "10,11"
+GPUArrays = "10.3, 11"
 KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 Reexport = "0.2, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Wavelets"
 uuid = "29a6e085-ba6d-5f35-a997-948ac2efa89a"
 version = "0.10.1"
-author = ["Gudmundur Adalsteinsson"]
+author = ["Gudmundur Adalsteinsson and contributors"]
 
 [workspace]
 projects = ["test", "benchmark"]
@@ -28,4 +28,4 @@ LinearAlgebra = "1"
 Reexport = "0.2, 1.0"
 SpecialFunctions = "0.7.1, 0.8, 0.9, 0.10, 1, 2"
 Statistics = "1"
-julia = "1"
+julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ WaveletsGPUExt = ["GPUArrays", "KernelAbstractions"]
 
 [compat]
 DSP = "0.5.1, 0.6, 0.7, 0.8"
-GPUArrays = "11"
+GPUArrays = "10,11"
 KernelAbstractions = "0.9"
 LinearAlgebra = "1"
 Reexport = "0.2, 1.0"


### PR DESCRIPTION
PR #108 went through without specifying compat entries for the extensions - oops!

Compat helper kindly suggested adding such entries in #109 and #110, but no CI tests were run on those PRs.

PR #111 now should ensure that CI is run on any PR.  I don't know any way of getting CI to run on older PRs like #109 and #110 so this PR should supersede those PRs, assuming CI passes.

Also making Julia v1.10 the minimum, and testing both v1.10 and latest v1.